### PR TITLE
ci: fix coverage comment permissions and remove duplicate reporter

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -101,24 +101,6 @@ jobs:
         echo ""
         echo "Note: pnpm audit endpoint is retired (HTTP 410). Use pnpm outdated instead."
 
-    - name: Check if coverage file exists
-      id: coverage-check
-      run: |
-        if [ -f "./coverage/merged/lcov.info" ]; then
-          echo "coverage-exists=true" >> $GITHUB_OUTPUT
-        else
-          echo "coverage-exists=false" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Comment coverage on PR
-      if: github.event_name == 'pull_request' && steps.coverage-check.outputs.coverage-exists == 'true'
-      uses: romeovs/lcov-reporter-action@v0.3.1
-      continue-on-error: true
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        lcov-file: ./coverage/merged/lcov.info
-        delete-old-comments: true
-
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v6
       continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests, component-tests]
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Añade `permissions: contents: read + pull-requests: write` al job `coverage-report` de `tests.yml` para que el comentario de cobertura en PRs pueda publicarse (antes fallaba con 403 `Resource not accessible by integration`).
- Elimina el paso duplicado `Comment coverage on PR` de `node.js.yml` (CI) — el reporter duplicado generaba valores incorrectos (NaN%) y competía con `tests.yml` vía `delete-old-comments`. Solo `tests.yml` reporta cobertura ahora.

## Testing performed
- Solo cambios de CI (`.github/workflows/*.yml`); sin cambios en `src/`.
- YAML validado.
- Verificación real: los checks de esta PR (incluido el comentario de cobertura en `tests.yml`).