### PR TITLE
fix: corregir code smells detectados por SonarQube

### DIFF
--- a/components/HeaderComponent.tsx
+++ b/components/HeaderComponent.tsx
@@ -79,7 +79,6 @@ export default function HeaderComponent() {
     return loading ? (
         <div>...Data Loading.....</div>
     ) : (
-        <>
             <header id="header" className="header d-flex align-items-center fixed-top color-react-azulclaro">
                 <div className="container-fluid container-xl d-flex align-items-center justify-content-between">
 
@@ -128,6 +127,5 @@ export default function HeaderComponent() {
                     </nav>
                 </div>
             </header>
-        </>
     )
 }

--- a/components/SliderComponent.tsx
+++ b/components/SliderComponent.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router"
-import { FormEvent } from "react"
+import { SubmitEvent } from "react"
 import Image from 'next/image';
 
 export default function SliderComponent() {
@@ -7,7 +7,7 @@ export default function SliderComponent() {
   const router = useRouter();
   const { push } = router;
 
-  async function buscarCursos(event: FormEvent<HTMLFormElement>) {
+  async function buscarCursos(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
     const query = formData.get('query');

--- a/docs/plans/2026-08-15-sonarqube-issues-fix.md
+++ b/docs/plans/2026-08-15-sonarqube-issues-fix.md
@@ -1,0 +1,41 @@
+# Plan: Corrección de issues de SonarQube
+
+- **Fecha:** 2026-08-15
+- **Herramienta/modelo:** opencode / big-pickle
+- **Estado:** done (verificado: lint OK, 126/126 Jest, 14/14 Cypress, build OK)
+
+## Objetivos
+
+Resolver todos los code smells reportados por SonarQube en el frontend React (Next.js).
+
+## Cambios de archivos
+
+| Archivo | Línea | Issue | Solución |
+| --- | --- | --- | --- |
+| `components/HeaderComponent.tsx` | 82 | Fragment con un solo hijo | Eliminar el fragment `<>...</>` redundante |
+| `components/SliderComponent.tsx` | 2, 10 | `FormEvent` deprecado en React 19 | Usar `SubmitEvent` (tipo no deprecado para `onSubmit`) |
+| `pages/404.tsx` | 6 | Fragment con un solo hijo | Eliminar el fragment redundante |
+| `pages/acceso.tsx` | 48 | Fragment con un solo hijo | Eliminar el fragment redundante |
+| `pages/carrito.tsx` | 32 | Condición negada inesperada | Invertir la lógica `if (!getToken())` a `if (getToken())` con bloques intercambiados |
+| `pages/registro.tsx` | 3 | Import sin especificadores (`import React, { }`) | Eliminar el import vacío (JSX transform automático) |
+| `pages/valoracion/[id].tsx` | 55 | Aserción innecesaria (`id as string`) | Quitar la aserción (ya es `string` tras el guard) |
+| `services/session.ts` | 6, 12, 19, 25, 31 | Preferir `globalThis.window` sobre `window` | Reemplazar `typeof window` por `typeof globalThis.window` |
+
+## Verificación
+
+1. `pnpm lint`
+2. `pnpm test-headless`
+3. `pnpm cypress:component`
+4. `pnpm build`
+
+## Decisiones de diseño
+
+- **`SubmitEvent` en SliderComponent:** React 19 deprecia `FormEvent`/`FormEventHandler`. El prop `onSubmit` de `@types/react` 19 usa `SubmitEventHandler`, cuyo tipo de evento `SubmitEvent` no está deprecado y mantiene `target: EventTarget & HTMLFormElement`.
+- **`globalThis.window`:** requiere ES2020, ya disponible en el tsconfig del proyecto.
+- Los tests existentes no dependen de los internals cambiados (fragments, tipos), salvo `session.ts` que se verifica con la suite completa.
+
+## Estado
+
+- [x] planned
+- [x] in progress
+- [x] done

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -3,18 +3,16 @@ import Image from "next/image"
 
 const Custom404: NextPage = () => {
   return (
-    <>
-      <div className="container pagina-datos">
-        <h1>Página no encontrada...</h1>
+    <div className="container pagina-datos">
+      <h1>Página no encontrada...</h1>
 
-        <div className="col-lg-5 order-1 order-lg-2 hero-img">
-          <Image src="/assets/img/hero-img.svg" width={500} height={500} className="img-fluid mb-3 mb-lg-0" alt="" />
-        </div>
-        <pre>
-          error 404
-        </pre>
+      <div className="col-lg-5 order-1 order-lg-2 hero-img">
+        <Image src="/assets/img/hero-img.svg" width={500} height={500} className="img-fluid mb-3 mb-lg-0" alt="" />
       </div>
-    </>
+      <pre>
+        error 404
+      </pre>
+    </div>
   )
 }
 

--- a/pages/acceso.tsx
+++ b/pages/acceso.tsx
@@ -45,27 +45,25 @@ const Acceso: NextPage = () => {
   }
 
   return (
-    <>
-      <div className="pagina-datos container">
-        <h1>Acceso a tu cuenta en el portal TFG</h1>
-        <div className="col-lg-8">
-          <form className="form-signin" onSubmit={submitForm}>
+    <div className="pagina-datos container">
+      <h1>Acceso a tu cuenta en el portal TFG</h1>
+      <div className="col-lg-8">
+        <form className="form-signin" onSubmit={submitForm}>
+        <div>
+              <label htmlFor="inputEmail" className="sr-only">Email address</label>
+              <input type="email" id="inputEmail" name="email" onChange={handleInput} value={formData.email} className="form-control" placeholder="Email address" required autoFocus/>
+          </div>
           <div>
-                <label htmlFor="inputEmail" className="sr-only">Email address</label>
-                <input type="email" id="inputEmail" name="email" onChange={handleInput} value={formData.email} className="form-control" placeholder="Email address" required autoFocus/>
-            </div>
-            <div>
-                <label htmlFor="inputPassword" className="sr-only">Password</label>
-                <input type="password" id="inputPassword" name="password" onChange={handleInput} value={formData.password} className="form-control" placeholder="Password" required/>
-            </div>
-            <div>
-                <button className="btn btn-primary btn-login" type="submit">Acceso</button>
-            </div>
-          </form>
-        </div>
-
+              <label htmlFor="inputPassword" className="sr-only">Password</label>
+              <input type="password" id="inputPassword" name="password" onChange={handleInput} value={formData.password} className="form-control" placeholder="Password" required/>
+          </div>
+          <div>
+              <button className="btn btn-primary btn-login" type="submit">Acceso</button>
+          </div>
+        </form>
       </div>
-    </>
+
+    </div>
   )
 }
 export default Acceso

--- a/pages/carrito.tsx
+++ b/pages/carrito.tsx
@@ -29,11 +29,7 @@ const Carrito: NextPage = () => {
        }
 
        const realizarCompra = ():void =>{
-            if (!getToken()) {
-            Swal.fire({ title: 'Debe tener iniciada sesión para comprar' })
-            router.push("/acceso");
-          }
-          else {
+            if (getToken()) {
             Swal.fire({
                 title: '¿Estas seguro de realizar la compra?',
                 text: "No se puede deshacer",
@@ -48,6 +44,10 @@ const Carrito: NextPage = () => {
               }).catch((error) => {
                 logger.error('Error en compra:', error)
               });
+          }
+          else {
+            Swal.fire({ title: 'Debe tener iniciada sesión para comprar' })
+            router.push("/acceso");
           }
 
        }

--- a/pages/registro.tsx
+++ b/pages/registro.tsx
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import { NextPage } from 'next'
-import React, { } from 'react'
 import { API_URL } from '../utils/constants'
 import Swal from 'sweetalert2'
 

--- a/pages/valoracion/[id].tsx
+++ b/pages/valoracion/[id].tsx
@@ -52,7 +52,7 @@ export async function getServerSideProps({ query }: NextPageContext) {
     return { notFound: true };
   }
 
-  const sanitizedId = Number.parseInt(id as string, 10);
+  const sanitizedId = Number.parseInt(id, 10);
 
   const res = await fetch(`${API_URL}/valoraciones/${sanitizedId}`)
   const valoracion = await res.json()

--- a/services/session.ts
+++ b/services/session.ts
@@ -3,32 +3,32 @@ import { logger } from '../utils/logger'
 import type { Usuario } from '../types'
 
 export function setToken(token: string): void {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         localStorage.setItem(TOKEN, token)
     }
 }
 
 export function getToken(): string {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         return localStorage.getItem(TOKEN) || '';
     }
     return '';
 }
 
 export function removeToken(): void {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         localStorage.removeItem(TOKEN);
     }
 }
 
 export function setUser(user: Usuario | string): void {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         localStorage.setItem(USER, typeof user === 'string' ? user : JSON.stringify(user));
     }
 }
 
 export function getUser(): Usuario | null {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         try {
             const user = localStorage.getItem(USER);
             return user ? (JSON.parse(user) as Usuario) : null;
@@ -41,7 +41,7 @@ export function getUser(): Usuario | null {
 }
 
 export function removeUser(): void {
-    if (typeof window !== 'undefined') {
+    if (typeof globalThis.window !== 'undefined') {
         localStorage.removeItem(USER);
     }
 }


### PR DESCRIPTION
## Descripción

Corrección de los code smells reportados por SonarQube en el frontend:

- **Fragmentos redundantes**: eliminados en `components/HeaderComponent.tsx`, `pages/404.tsx` y `pages/acceso.tsx`
- **`FormEvent` deprecado**: reemplazado por `SubmitEvent` (tipo no deprecado para `onSubmit` en React 19) en `components/SliderComponent.tsx`
- **Condición negada**: invertida la lógica `if (!getToken())` en `pages/carrito.tsx`
- **Import vacío**: eliminado `import React, { }` en `pages/registro.tsx`
- **Aserción innecesaria**: quitado `id as string` en `pages/valoracion/[id].tsx`
- **`globalThis.window`**: sustituido `typeof window` en `services/session.ts` (6 ocurrencias)

## Verificación

- [x] `pnpm lint`
- [x] `pnpm test-headless` (126 tests)
- [x] `pnpm cypress:component` (14 tests)
- [x] `pnpm build`

Plan documentado en `docs/plans/2026-08-15-sonarqube-issues-fix.md`.