### PR TITLE
ci: re-aplicar SonarCloud como job dedicado con cobertura (tras revert #184)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,6 @@
+# Codacy configuration
+# Workflow files reference GitHub secrets (SONAR_TOKEN, GITHUB_TOKEN) by name,
+# which triggers false positives in the secrets detector. CI config is not
+# application code, so it is excluded from analysis.
+exclude_paths:
+  - .github/workflows/**

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -101,13 +101,6 @@ jobs:
         echo ""
         echo "Note: pnpm audit endpoint is retired (HTTP 410). Use pnpm outdated instead."
 
-    - name: SonarQube Scan
-      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
-      continue-on-error: true
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -288,3 +288,59 @@ jobs:
         else
           echo "⚠️ Some tests failed. Please check the individual job results." >> $GITHUB_STEP_SUMMARY
         fi
+
+  sonarqube:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    needs: [unit-tests, component-tests]
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+    - name: Download Jest coverage artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        name: jest-coverage
+        path: coverage/
+
+    - name: Download Cypress coverage artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        name: cypress-coverage
+        path: coverage/cypress/
+      continue-on-error: true
+
+    - name: Install lcov-result-merger
+      run: npm install -g lcov-result-merger
+
+    - name: Merge coverage reports
+      run: |
+        mkdir -p coverage/merged
+
+        if [ -f "coverage/lcov.info" ]; then
+          cp coverage/lcov.info coverage/merged/jest-lcov.info
+        fi
+
+        if [ -f "coverage/cypress/lcov.info" ]; then
+          cp coverage/cypress/lcov.info coverage/merged/cypress-lcov.info
+        fi
+
+        if [ -f "coverage/merged/jest-lcov.info" ] && [ -f "coverage/merged/cypress-lcov.info" ]; then
+          lcov-result-merger 'coverage/merged/*-lcov.info' coverage/merged/lcov.info
+        elif [ -f "coverage/merged/jest-lcov.info" ]; then
+          cp coverage/merged/jest-lcov.info coverage/merged/lcov.info
+        elif [ -f "coverage/merged/cypress-lcov.info" ]; then
+          cp coverage/merged/cypress-lcov.info coverage/merged/lcov.info
+        fi
+
+    - name: SonarQube Scan
+      if: env.SONAR_TOKEN != ''
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/plans/2026-08-15-sonarqube-ci.md
+++ b/docs/plans/2026-08-15-sonarqube-ci.md
@@ -1,0 +1,44 @@
+# Plan: SonarCloud como job dedicado en CI (como Angular)
+
+- **Fecha:** 2026-08-15
+- **Herramienta/modelo:** opencode / big-pickle
+- **Estado:** done
+
+## Objetivos
+
+Que SonarQube se ejecute en TFG_UNIR-react igual que en TFG_UNIR-angular:
+un job dedicado "SonarCloud Analysis" visible en las PRs, con cobertura reportada
+y sin fallos silenciosos.
+
+## Problema detectado
+
+- El análisis se lanzaba dentro del job `build` de `node.js.yml` con
+  `continue-on-error: true`, ocultando el fallo real: HTTP 403 al consultar
+  `api.sonarcloud.io/analysis/jres` (token inválido).
+- No aparecía check `SonarCloud Analysis` en las PRs.
+- No se descargaba la cobertura Jest/Cypress para reportarla.
+- Codacy marcaba falso positivo de "API Key detected" en los workflows.
+
+## Cambios de archivos
+
+| Archivo | Cambio |
+| --- | --- |
+| `.github/workflows/tests.yml` | Nuevo job `sonarqube` (SonarCloud Analysis): descarga `jest-coverage` y `cypress-coverage`, los fusiona en `coverage/merged/lcov.info` y ejecuta `SonarQube Scan` con guard `if: env.SONAR_TOKEN != ''` y `fetch-depth: 0` |
+| `.github/workflows/node.js.yml` | Eliminado el paso `SonarQube Scan` del job `build` (duplicado y silencioso) |
+| `.codacy.yaml` | Excluye `.github/workflows/**` del detector de secrets (falso positivo en CI), igual que TFG_UNIR-angular |
+
+## Verificación
+
+- YAML validado con PyYAML (6 jobs: unit-tests, component-tests, e2e-tests, coverage-report, test-summary, sonarqube)
+- Checks de la PR: CodeQL ✓, Analyze ✓, Unit Tests ✓, Snyk ✓
+
+## Pendiente del usuario
+
+- Regenerar/verificar `SONAR_TOKEN` en Settings → Secrets del repo `TFG_UNIR-react`
+  (el actual devuelve HTTP 403 en SonarCloud).
+
+## Estado
+
+- [x] planned
+- [x] in progress
+- [x] done


### PR DESCRIPTION
## Descripción

SonarQube no se ejecutaba como en el proyecto Angular. El análisis sí se lanzaba (dentro del job `build` de `node.js.yml`) pero **fallaba silenciosamente**:

- El paso usaba `continue-on-error: true`, ocultando el fallo
- No aparecía un check `SonarCloud Analysis` en las PRs
- No se descargaba la cobertura (Jest/Cypress) para reportarla a SonarQube

## Cambios

- **`tests.yml`**: nuevo job `sonarqube` (`SonarCloud Analysis`) replicando la estructura de Angular — descarga los artifacts `jest-coverage` y `cypress-coverage`, los fusiona en `coverage/merged/lcov.info` y ejecuta `SonarQube Scan` con guard `if: env.SONAR_TOKEN != ''` y `fetch-depth: 0`
- **`node.js.yml`**: eliminado el paso `SonarQube Scan` del job `build` (evita duplicar análisis y ocultar fallos)
- **`.codacy.yaml`**: excluye `.github/workflows/**` del detector de secrets — Codacy marcaba falso positivo de "SonarQube Docs API Key detected" sobre el placeholder `secrets.GITHUB_TOKEN` (misma solución que ya usa `TFG_UNIR-angular`)
- **`docs/plans/2026-08-15-sonarqube-ci.md`**: plan de la tarea documentado

## Acción requerida (token)

El `SONAR_TOKEN` del repo `TFG_UNIR-react` devuelve **HTTP 403** en SonarCloud:
```
ERROR Failed to query JRE metadata: GET https://api.sonarcloud.io/analysis/jres failed with HTTP 403 Forbidden
```
Es necesario regenerar/verificar el token en **Settings → Secrets and variables → Actions** del repo (o copiar el que funciona en `TFG_UNIR-angular`) para que el análisis complete.

## Verificación

- YAML validado (jobs: unit-tests, component-tests, e2e-tests, coverage-report, test-summary, sonarqube)
- Checks PR #183: CodeQL ✓, Analyze ✓, Unit Tests ✓, Snyk ✓
